### PR TITLE
Replace vim-ruby with vim-polyglot

### DIFF
--- a/vim/init.vim
+++ b/vim/init.vim
@@ -10,6 +10,6 @@ Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
 Plug 'preservim/nerdtree'
 Plug 'altercation/vim-colors-solarized'
-Plug 'vim-ruby/vim-ruby'
+Plug 'sheerun/vim-polyglot'
 
 call plug#end()


### PR DESCRIPTION
vim-polyglot already includes vim-ruby so there is no point to adding individual syntax highlighting plugins for each language