### PR TITLE
Add git-related vim plugins

### DIFF
--- a/vim/after/plugin/options.vim
+++ b/vim/after/plugin/options.vim
@@ -18,3 +18,6 @@ autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists('s:std_in
 
 " Exit Vim if NERDTree is the only window remaining in the only tab.
 autocmd BufEnter * if tabpagenr('$') == 1 && winnr('$') == 1 && exists('b:NERDTree') && b:NERDTree.isTabTree() | quit | endif
+
+" Change color of vim-gitgutter column
+highlight clear SignColumn

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -11,5 +11,7 @@ Plug 'junegunn/fzf.vim'
 Plug 'preservim/nerdtree'
 Plug 'altercation/vim-colors-solarized'
 Plug 'sheerun/vim-polyglot'
+Plug 'tpope/vim-fugitive'
+Plug 'airblade/vim-gitgutter'
 
 call plug#end()


### PR DESCRIPTION
This adds vim-fugitive and vim-gitgutter to assist with Git-related things. The goal is to keep it light because Git should be done in the command line and not inside vim.