### PR TITLE
Convert NERDTree menu to minimal to fix bug with latest version of vim

### DIFF
--- a/vim/after/plugin/options.vim
+++ b/vim/after/plugin/options.vim
@@ -19,6 +19,10 @@ autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists('s:std_in
 " Exit Vim if NERDTree is the only window remaining in the only tab.
 autocmd BufEnter * if tabpagenr('$') == 1 && winnr('$') == 1 && exists('b:NERDTree') && b:NERDTree.isTabTree() | quit | endif
 
+" Temporary fix for NERDTree bug with latest version of neovim
+" https://github.com/preservim/nerdtree/issues/1321
+let g:NERDTreeMinimalMenu=1
+
 " Change vim-airline theme to Solarized Light
 let g:airline_theme='solarized'
 


### PR DESCRIPTION
For some reason, the NERDTree menu doesn't disappear after using it which leaves a huge buffer in the bottom that can't be closed.

There is an open pull request to fix this issue, but it hasn't been merged yet. In the mean time, this is the temporary fix for this situation.