### PR TITLE
Automatically resize existing vim panes/splits when using NERDTree

### DIFF
--- a/vim/after/plugin/key_bindings.vim
+++ b/vim/after/plugin/key_bindings.vim
@@ -5,6 +5,6 @@ nnoremap <C-p> :Files<cr>
 nnoremap <silent> <Leader>f :Rg<CR>
 
 " NERDTree Bindings
-nnoremap <leader>n :NERDTreeFocus<CR>
-nnoremap <C-n> :NERDTreeToggle<CR>
-nnoremap <C-f> :NERDTreeFind<CR>
+nnoremap <leader>n :NERDTreeFocus<CR> <bar> <C-w>=
+nnoremap <C-n> :NERDTreeToggle<CR> <bar> <C-w>=
+nnoremap <C-f> :NERDTreeFind<CR> <bar> <C-w>=


### PR DESCRIPTION
Opening or closing NERDTree makes existing pane sizes weird.

This solves that issue by calling <CTRL + w> + = to resize everything whenever NERDTree is opened or closed